### PR TITLE
Silo ht5

### DIFF
--- a/.beans/silo-b21--integrate-rspec-into-rakefile.md
+++ b/.beans/silo-b21--integrate-rspec-into-rakefile.md
@@ -1,11 +1,11 @@
 ---
 # silo-b21
 title: Integrate RSpec into Rakefile
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-02-12T15:27:16Z
-updated_at: 2026-02-12T15:28:05Z
+updated_at: 2026-02-12T19:46:36Z
 parent: silo-ht5
 blocking:
     - silo-d07
@@ -14,6 +14,6 @@ blocking:
 Add RSpec core rake task to the Rakefile to allow running unit tests via 'rake spec'.
 
 ## Checklist
-- [ ] Add 'rspec/core/rake_task' to Rakefile
-- [ ] Define :spec rake task
-- [ ] Ensure RACK_ENV=test is set
+- [x] Add 'rspec/core/rake_task' to Rakefile
+- [x] Define :spec rake task
+- [x] Ensure RACK_ENV=test is set

--- a/.beans/silo-d07--implement-unified-rake-test-task.md
+++ b/.beans/silo-d07--implement-unified-rake-test-task.md
@@ -1,17 +1,17 @@
 ---
 # silo-d07
 title: Implement Unified 'rake test' Task
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-02-12T15:27:41Z
-updated_at: 2026-02-12T15:28:31Z
+updated_at: 2026-02-12T19:46:25Z
 parent: silo-ht5
 ---
 
 Create a top-level 'test' task that runs both RSpec and Cucumber tests.
 
 ## Checklist
-- [ ] Define :test task in Rakefile
-- [ ] Make :test depend on :spec and :cucumber
-- [ ] Set as default task (optional but recommended)
+- [x] Define :test task in Rakefile
+- [x] Make :test depend on :spec and :cucumber
+- [x] Set as default task (optional but recommended)

--- a/.beans/silo-h4c--fix-rspec-load-path-and-disable-failing-tests.md
+++ b/.beans/silo-h4c--fix-rspec-load-path-and-disable-failing-tests.md
@@ -1,17 +1,17 @@
 ---
 # silo-h4c
 title: Fix RSpec Load Path and Disable Failing Tests
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-02-12T15:27:26Z
-updated_at: 2026-02-12T15:28:16Z
+updated_at: 2026-02-12T19:46:20Z
 parent: silo-ht5
 ---
 
 The RSpec tests currently fail to load 'silo_night' and have one failing example. These need to be addressed by fixing the load path and disabling the failing tests as per the requirement.
 
 ## Checklist
-- [ ] Fix load path issue in RSpec (e.g., in spec_helper.rb)
-- [ ] Identify failing RSpec tests
-- [ ] Disable failing RSpec tests using 'xit' or 'pending'
+- [x] Fix load path issue in RSpec (e.g., in spec_helper.rb)
+- [x] Identify failing RSpec tests
+- [x] Disable failing RSpec tests using 'xit' or 'pending'

--- a/.beans/silo-ht5--include-tests-in-rakefile.md
+++ b/.beans/silo-ht5--include-tests-in-rakefile.md
@@ -5,7 +5,7 @@ status: completed
 type: feature
 priority: critical
 created_at: 2026-02-12T15:17:11Z
-updated_at: 2026-02-12T19:15:20Z
+updated_at: 2026-02-12T19:46:41Z
 ---
 
 Ensure that the Rakefile has a test namespace, and runs test for both cucumber and rspec. Get tests to a passing state. Do not fix the tests, disable tests that are not passing (for now) so that they can be addressed and fixed later.

--- a/.beans/silo-kcb--automate-test-database-preparation-in-rakefile.md
+++ b/.beans/silo-kcb--automate-test-database-preparation-in-rakefile.md
@@ -1,11 +1,11 @@
 ---
 # silo-kcb
 title: Automate Test Database Preparation in Rakefile
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-02-12T15:27:36Z
-updated_at: 2026-02-12T15:28:26Z
+updated_at: 2026-02-12T19:46:31Z
 parent: silo-ht5
 blocking:
     - silo-b21
@@ -15,5 +15,5 @@ blocking:
 Ensure the test database is migrated before running tests to avoid 'migrations not up to date' errors.
 
 ## Checklist
-- [ ] Add a task to migrate the test database
-- [ ] Make :spec and :cucumber depend on test database migration
+- [x] Add a task to migrate the test database
+- [x] Make :spec and :cucumber depend on test database migration

--- a/.beans/silo-nkw--integrate-cucumber-into-rakefile.md
+++ b/.beans/silo-nkw--integrate-cucumber-into-rakefile.md
@@ -1,11 +1,11 @@
 ---
 # silo-nkw
 title: Integrate Cucumber into Rakefile
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-02-12T15:27:21Z
-updated_at: 2026-02-12T15:28:11Z
+updated_at: 2026-02-12T19:46:10Z
 parent: silo-ht5
 blocking:
     - silo-d07
@@ -14,6 +14,6 @@ blocking:
 Add Cucumber rake task to the Rakefile to allow running integration tests via 'rake cucumber'.
 
 ## Checklist
-- [ ] Add 'cucumber/rake/task' to Rakefile
-- [ ] Define :cucumber rake task
-- [ ] Ensure it uses the default profile
+- [x] Add 'cucumber/rake/task' to Rakefile
+- [x] Define :cucumber rake task
+- [x] Ensure it uses the default profile

--- a/.beans/silo-p29--disable-failing-cucumber-scenarios.md
+++ b/.beans/silo-p29--disable-failing-cucumber-scenarios.md
@@ -1,17 +1,17 @@
 ---
 # silo-p29
 title: Disable Failing Cucumber Scenarios
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-02-12T15:27:31Z
-updated_at: 2026-02-12T15:28:21Z
+updated_at: 2026-02-12T19:46:15Z
 parent: silo-ht5
 ---
 
 Most Cucumber scenarios are failing because the test database is not properly seeded or users are missing. These should be disabled for now.
 
 ## Checklist
-- [ ] Identify all failing Cucumber scenarios
-- [ ] Disable failing scenarios (e.g., using @wip tag or marking as pending)
-- [ ] Verify cucumber command exits with 0
+- [x] Identify all failing Cucumber scenarios
+- [x] Disable failing scenarios (e.g., using @wip tag or marking as pending)
+- [x] Verify cucumber command exits with 0

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,82 @@
+# Testing Guide
+
+This document provides instructions on how to execute and manage the test suites for the Silo Night project.
+
+## Overview
+
+The project uses two primary testing frameworks:
+- **RSpec:** Used for unit and functional testing of Ruby classes and models.
+- **Cucumber:** Used for behavior-driven development (BDD) and integration testing of the web interface and API.
+
+## Prerequisites
+
+Before running tests, ensure your environment is set up and dependencies are installed:
+
+```bash
+bundle install
+```
+
+## Running Tests via Rake (Recommended)
+
+The project includes a unified testing task in the `Rakefile` that handles database preparation and executes both suites.
+
+### Run all tests
+
+This command will migrate the test database and run both RSpec and Cucumber:
+
+```bash
+RACK_ENV=test bundle exec rake test
+```
+
+*Note: `rake test` is the default task, so `RACK_ENV=test bundle exec rake` also works.*
+
+### Run specific suites
+
+You can run the suites individually while still ensuring the test environment is used:
+
+```bash
+# Run only RSpec
+RACK_ENV=test bundle exec rake spec
+
+# Run only Cucumber
+RACK_ENV=test bundle exec rake cucumber
+```
+
+## Handling Failing Tests
+
+Currently, several tests in both RSpec and Cucumber are failing due to missing seed data or pending implementation. To maintain a passing CI baseline, these tests have been tagged and are skipped by default.
+
+### RSpec Skipped Tests
+Failing specs are tagged with `failing: true`.
+- To run only the passing tests: `bundle exec rspec --tag ~failing`
+- To include the failing tests: `bundle exec rspec`
+
+### Cucumber Skipped Scenarios
+Failing scenarios are tagged with `@failing`.
+- To run only the passing scenarios: `bundle exec cucumber --tags "not @failing"`
+- To include the failing scenarios: `bundle exec cucumber`
+
+## Test Database Management
+
+The testing suite is configured to use an isolated SQLite database located at `data/test.db`.
+
+### Manual Migration
+If you need to manually migrate the test database:
+
+```bash
+RACK_ENV=test bundle exec rake db:migrate
+```
+
+### Seeding
+If a test requires the standard seed data, you can seed the test database:
+
+```bash
+RACK_ENV=test bundle exec rake db:seed
+```
+
+## Test Structure
+
+- `spec/`: Contains RSpec tests and FactoryBot definitions.
+- `features/`: Contains Cucumber `.feature` files and step definitions.
+- `features/support/env.rb`: Configuration for the Cucumber test environment.
+- `spec/spec_helper.rb`: Configuration for the RSpec test environment.

--- a/features/silo_night_api.feature
+++ b/features/silo_night_api.feature
@@ -4,35 +4,42 @@ Feature: silo-night API
     When any user sends a request to the main page
     Then the site responds with an OK code
 
+  @failing
   Scenario: Return a user's show list through the API
     When "steph" sends an API request for a list of shows
     Then the site responds with JSON
     And the site responds with text containing "Equalizer"
 
+  @failing
   Scenario: Return a different user's show list through the API
     When "justin" sends an API request for a list of shows
     Then the site responds with JSON
     And the site responds with text containing "His Dark Materials"
     And the site responds with text not containing "The Amazing Race"
 
+  @failing
   Scenario: User deletes a show
     When "steph" sends an API request to delete "suits" from the list
     Then the site responds with an OK code
     And the site responds with text not containing "Suits"
 
+  @failing
   Scenario: User adds a show
     When "test" sends an API request to add "Platonic" to the list
     Then the site responds with an OK code
     And the site responds with text containing "Platonic"
 
+  @failing
   Scenario: Return a 404 when a show is not found for a user
     When "justin" sends an API request to delete "foo" from the list
     Then the site responds with a 404 error code
 
+  @failing
   Scenario: Show user's schedule based on seeded data
     When "steph" sends an API request to view the schedule
     Then the show "The Afterparty" is scheduled for "Thursday"
 
+  @failing
   Scenario: Remove and add a show and generate a new schedule
     Given "steph" sends an API request to delete "Suits" from the list
       And "steph" sends an API request to add "The Amazing Race" to the list

--- a/features/silo_night_ui.feature
+++ b/features/silo_night_ui.feature
@@ -6,11 +6,13 @@ Feature: silo-night user interface
     When any user visits the main page
     Then the page displays "Create a new schedule"
 
+  @failing
   Scenario: steph views her list of shows to watch
     When the user "steph" views her list of shows
     Then the page displays "The Equalizer"
     And the page displays "Grey&#39;s Anatomy"
 
+  @failing
   Scenario: Stephanie edits her list of shows
     When the user "steph" visits the page to edit her shows
     Then the page displays a form with "Add" text

--- a/spec/show_spec.rb
+++ b/spec/show_spec.rb
@@ -26,7 +26,7 @@ describe Show do
     expect(s.average_runtime).to eq(30)
   end
 
-  it "gets average from second line in seed data" do
+  it "gets average from second line in seed data", failing: true do
     s = Show[2]
     expect(s.average_runtime).to eq(48)
   end

--- a/spec/silo_night_spec.rb
+++ b/spec/silo_night_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Silo Night app' do
     expect(last_response.body).to include("Create")
   end
 
-  it "creates a new schedule" do
+  it "creates a new schedule", failing: true do
     post '/schedule'
     expect(last_response).to be_ok
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+ENV['RACK_ENV'] = 'test'
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('..', __dir__)
+
 require 'factory_bot'
 require 'sequel'
 require 'sequel/extensions/migration'
@@ -6,7 +10,6 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
-    ENV['RACK_ENV'] = 'test'
     db_url = ENV['DATABASE_URL'] || 'sqlite://data/test.db'
     db = Sequel.connect(db_url)
     unless Sequel::Migrator.is_current?(db, 'db/migrations')

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -22,7 +22,7 @@ describe User do
     expect(sched["Tuesday"]).to include("Suits")
   end
 
-  it "loads from a file with shows included" do
+  it "loads from a file with shows included", failing: true do
     bot1_test.load_from_file("./data/test.json")
     expect(bot1_test.name).to eq("test")
     expect(bot1_test.shows_dataset).not_to be_empty
@@ -60,7 +60,7 @@ describe User do
 
   end
 
-  it "confirm show class from user seed data" do
+  it "confirm show class from user seed data", failing: true do
     expect(bot1_test.shows[0].class.name).to eq("Show")
   end
 
@@ -84,7 +84,7 @@ describe User do
   #  expect(actual).to eq(32)
   #end
 
-  it "generates populated schedule from first seeded user" do
+  it "generates populated schedule from first seeded user", failing: true do
 
     seed_just.generate_schedule()
     weekday = "Tuesday"


### PR DESCRIPTION
# PR Summary: silo-ht5 - Include tests in Rakefile

This PR completes the feature `silo-ht5`, which aimed to integrate the project's test suites (RSpec and Cucumber) into the `Rakefile` and establish a stable, passing test baseline by disabling currently failing tests.

## Completed Tasks

### [silo-ht5] Include tests in Rakefile
Integrated testing infrastructure into the project's automation via Rake. Established namespaces and unified tasks to ensure tests are easily runnable and integrated into the development workflow.

### [silo-b21] Integrate RSpec into Rakefile
- Integrated `rspec/core/rake_task` into the `Rakefile`.
- Defined the `:spec` task to execute unit tests.
- Ensured the test environment (`RACK_ENV=test`) is properly initialized.

### [silo-nkw] Integrate Cucumber into Rakefile
- Integrated `cucumber/rake/task` into the `Rakefile`.
- Defined the `:cucumber` task for integration testing.
- Fixed tag syntax compatibility issues (`not @failing`) for the latest Cucumber version.

### [silo-kcb] Automate Test Database Preparation in Rakefile
- Automated database migrations for the test environment.
- Configured `:spec` and `:cucumber` tasks to depend on successful database migrations, preventing "out of date" errors.

### [silo-d07] Implement Unified 'rake test' Task
- Created a top-level `test` task that executes the full suite (migrations, RSpec, and Cucumber).
- Configured this unified task as the default Rake task for the project.

### [silo-h4c] Fix RSpec Load Path and Disable Failing Tests
- Resolved load path issues in `spec_helper.rb` to ensure models and application code are correctly required.
- Identified and tagged 5 failing RSpec tests with `failing: true`.
- Configured Rake to exclude these tagged tests from the standard run.

### [silo-p29] Disable Failing Cucumber Scenarios
- Identified 9 failing integration scenarios.
- Tagged these scenarios with `@failing`.
- Verified that the Cucumber suite now exits successfully by skipping these problematic scenarios.

## Impact
Developers can now run the entire test suite using a single command: `bundle exec rake`. This ensures that the test database is always in the correct state and provides a reliable baseline for further development and bug fixing.
