### PR TITLE
Fix: Unified metadata runtime format in MetadataService

### DIFF
--- a/lib/metadata_service.rb
+++ b/lib/metadata_service.rb
@@ -127,6 +127,6 @@ class MetadataService
     
     rt ||= tvmaze_data&.fetch('averageRuntime', nil) || tvmaze_data&.fetch('runtime', nil)
     
-    rt ? "#{rt} min" : "unknown"
+    rt ? "#{rt} minutes" : "unknown"
   end
 end


### PR DESCRIPTION
## Summary
Fixed a failing test in MetadataService where the runtime format was 'min' instead of 'minutes'.

## Changes
- Updated lib/metadata_service.rb to return 'minutes' instead of 'min' in calculate_runtime.
- This ensures consistency with existing show data and passes the unit test in spec/metadata_service_spec.rb.

## Testing
- [x] RSpec tests passed (spec/metadata_service_spec.rb)
- [x] All RSpec and Cucumber tests pass