### PR TITLE
Work on #33: BUG: UI hides enabled days with zero-time budget

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-# TODO: Issue #33 - UI hides enabled days with zero-time budget
-
-- [x] Confirm the failure by running cucumber without the `@failing` tag.
-- [x] Modify `template/schedule.slim` to ensure enabled days are always displayed.
-- [x] Verify the fix by running cucumber again.
-- [x] Clean up `TODO.md` and finalize PR.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO: Issue #33 - UI hides enabled days with zero-time budget
+
+- [ ] Confirm the failure by running cucumber without the `@failing` tag.
+- [ ] Modify `template/schedule.slim` to ensure enabled days are always displayed.
+- [ ] Verify the fix by running cucumber again.
+- [ ] Clean up `TODO.md` and finalize PR.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO: Issue #33 - UI hides enabled days with zero-time budget
 
-- [ ] Confirm the failure by running cucumber without the `@failing` tag.
-- [ ] Modify `template/schedule.slim` to ensure enabled days are always displayed.
-- [ ] Verify the fix by running cucumber again.
-- [ ] Clean up `TODO.md` and finalize PR.
+- [x] Confirm the failure by running cucumber without the `@failing` tag.
+- [x] Modify `template/schedule.slim` to ensure enabled days are always displayed.
+- [x] Verify the fix by running cucumber again.
+- [x] Clean up `TODO.md` and finalize PR.

--- a/features/final_guide.feature
+++ b/features/final_guide.feature
@@ -28,7 +28,6 @@ Feature: Final Watch Guide
     And the user views their final guide
     Then "Monday" schedule should show "Foundation"
 
-  @failing
   Scenario: Investigation - Enabled days with zero time are visible in the UI (Reason #3)
     Given the user "investigator" exists
     When the user enables "Wednesday" but sets time to "0" minutes

--- a/template/schedule.slim
+++ b/template/schedule.slim
@@ -10,7 +10,7 @@ h1
   - total = @user.total_day_time(abbr)
   - shows = @schedule[day] || []
   
-  - if total > 0 || !shows.empty? || !@user.day_enabled?(abbr)
+  - if @user.day_enabled?(abbr) || !shows.empty? || total > 0
     h2 class=(is_today ? "active" : "")
       = day
       |  (#{total} min)
@@ -20,5 +20,5 @@ h1
       ul
         - shows.each do |show|
           li: h3 #{show}
-    - elsif total == 0 && !@user.day_enabled?(abbr)
+    - else
       p No TV tonight

--- a/template/schedule.slim
+++ b/template/schedule.slim
@@ -10,15 +10,14 @@ h1
   - total = @user.total_day_time(abbr)
   - shows = @schedule[day] || []
   
-  - if @user.day_enabled?(abbr) || !shows.empty? || total > 0
-    h2 class=(is_today ? "active" : "")
-      = day
-      |  (#{total} min)
-      - if is_today && !shows.empty?
-        span style="margin-left: 20px; font-size: 70%; color: orange;" Watch Tonight
-    - if !shows.empty?
-      ul
-        - shows.each do |show|
-          li: h3 #{show}
-    - else
-      p No TV tonight
+  h2 class=(is_today ? "active" : "")
+    = day
+    |  (#{total} min)
+    - if is_today && !shows.empty?
+      span style="margin-left: 20px; font-size: 70%; color: orange;" Watch Tonight
+  - if !shows.empty?
+    ul
+      - shows.each do |show|
+        li: h3 #{show}
+  - else
+    p No TV tonight


### PR DESCRIPTION
## Summary
Fixes a bug where enabled days with zero-time budget and no scheduled shows were hidden in the UI.

## Changes
- Modified `template/schedule.slim` to ensure days enabled in the user config are always displayed.
- Updated logic to show 'No TV tonight' for enabled days without scheduled shows.
- Removed `@failing` tag from the now-passing scenario in `features/final_guide.feature`.

## Testing
- [x] Verified that 'Investigation - Enabled days with zero time are visible in the UI (Reason #3)' passes.
- [x] Confirmed that other unrelated failing tests remain failing as requested.