### PR TITLE
Initialize API v1 (TDD & Architectural Refactor)

### DIFF
--- a/docs/architecture_proposal_api_v1.md
+++ b/docs/architecture_proposal_api_v1.md
@@ -1,0 +1,96 @@
+# Architectural Proposal: API v1 Refactor (TDD-Driven Service & Presenter Layers)
+
+## Status: Proposed
+**Author:** Software Architect (Consultant)  
+**Date:** April 3, 2026  
+**Target Audience:** Engineering Team
+
+---
+
+## 1. Context & Objectives
+The current `api/v0.1` implementation in `silo_night.rb` suffers from "Fat Route" syndrome, where business logic and HTTP concerns are intertwined. To support rapid UI prototyping and ensure long-term maintainability, we will transition to a **Test-Driven Development (TDD)** approach for all `v1` API development.
+
+### Primary Goals:
+1.  **Strict TDD Workflow:** Use the Red-Green-Refactor cycle to define API contracts before implementation.
+2.  **Decouple Logic from HTTP:** Move business rules into testable Service objects.
+3.  **Standardize Data Contracts:** Use Presenters to ensure consistent, rich JSON output for all UI prototypes.
+
+---
+
+## 2. Core Development Cycle: Red-Green-Refactor
+
+All new `v1` features must follow this strict cycle:
+
+1.  **🔴 Red (Test First):** Write an RSpec request spec that defines the expected JSON response and HTTP status for the new `v1` endpoint. Run the test and confirm it fails.
+2.  **🟢 Green (Pass Fast):** Implement the minimal amount of code—likely directly in the Sinatra route initially—to satisfy the test. Confirm the test passes.
+3.  **🔵 Refactor (Architect):** Extract the inline logic into its appropriate **Service** (for logic) or **Presenter** (for output formatting). Run the tests again to ensure no regressions occurred during the extraction.
+
+---
+
+## 3. The `ShowService` (Orchestration Layer)
+
+### Purpose
+The `ShowService` acts as the "Single Source of Truth" for operations involving shows, coordinating between the database and `MetadataService`.
+
+### Responsibilities
+- **Search & Create:** Searching for shows locally; fetching and persisting metadata if missing.
+- **User Association:** Managing a user's collection and triggering side effects (like schedule regeneration).
+- **Transaction Management:** Ensuring atomic updates for complex operations like list reordering.
+
+---
+
+## 4. The `ShowPresenter` (Representation Layer)
+
+### Purpose
+Presenters transform raw models into the versioned JSON contracts required by the front-end.
+
+### Responsibilities
+- **Schema Enforcement:** Whitelisting fields and ensuring consistent types (e.g., integers for runtimes).
+- **Data Decoration:** Calculating dynamic fields like full poster URLs or formatted dates.
+
+---
+
+## 5. Roadmap: Planned Services & Presenters
+
+To achieve full decoupling, the following objects are identified for implementation:
+
+### Service Objects
+- **`ShowService`:** Handles show lookup, metadata fetching, and creation.
+- **`UserShowService`:** Manages the relationship between users and shows (adding, removing, reordering).
+- **`ScheduleService`:** Encapsulates the logic for generating and formatting a user's weekly viewing schedule.
+- **`UserConfigService`:** Manages user settings, credentials, and profile metadata.
+- **`SearchService`:** Orchestrates multi-provider searches (Local DB + TMDB + TVMaze).
+
+### Presenter Objects
+- **`ShowPresenter`:** Standardized JSON for show details and list items.
+- **`SchedulePresenter`:** Formats the complex schedule hash into a UI-friendly structure.
+- **`UserPresenter`:** Represents user profiles and their associated configurations.
+- **`SearchResultPresenter`:** Normalizes search results from different external APIs into a uniform UI format.
+- **`ErrorPresenter`:** Standardizes error responses (e.g., `{ "error": "ShowNotFound", "message": "..." }`).
+
+---
+
+## 6. Assumptions & Biases
+
+### Technical Assumptions
+- **Persistence Layer Stability:** We assume the underlying Sequel-based schema (especially the `User` and `Show` models) is structurally sound enough to support new features without a full migration. Our refactor focuses on how we *interact* with this data, not how it is stored.
+- **External API Volatility:** We assume that external providers (TMDB, TVMaze) are volatile. This architectural design biases toward a strong "Adapter" pattern within the Service layer to ensure that a change in the TMDB API doesn't leak into our UI JSON contracts.
+- **Statelessness Preference:** While the current app uses some server-side rendering, we assume the future UI prototypes will favor a "Client-Side State" model. Our API v1 will be designed as a stateless resource provider, minimizing reliance on Sinatra-level session management.
+- **Environment Parity:** We assume that the `test` environment is (or will be) configured with stable mocks for external services, allowing the TDD cycle to run without actual network calls to TMDB/TVMaze.
+
+### Architectural Biases
+- **Contract-First Design (TDD):** We bias heavily toward the API "Contract" as the primary deliverable. In this view, the backend is a service provider, and the JSON schema is the legal agreement between the backend and front-end teams.
+- **Request-Level Verification over Unit Tests:** While unit tests have value, we bias toward RSpec **Request Specs** for the v1 refactor. This ensures that the *entire stack* (Route -> Service -> Model -> Presenter) is working together to deliver the correct contract, providing higher confidence during aggressive refactors.
+- **"Thin Model, Thick Service" Philosophy:** We bias against adding business logic (like schedule generation or metadata fetching) directly to the `User` or `Show` models. We prefer keeping models as "Anemic" data containers and moving orchestration to Service Objects to prevent "God Objects" and circular dependencies.
+- **Explicit Representation (Presenters):** We bias against using `to_json` overrides in models. We believe a model's data should be separate from its representation. Using explicit Presenters allows us to provide different "Views" of the same data (e.g., a `SummaryShowPresenter` for lists and a `FullShowPresenter` for details) without polluting the model.
+- **Standardized Failure States:** We bias toward "Error Objects" over HTTP status codes alone. Every failure should return a predictable JSON payload, allowing the front-end to implement robust, user-friendly error handling for any UI prototype.
+- **v0.1 Preservation:** We bias toward a "Side-by-Side" migration. We will not touch or "improve" the `v0.1` namespace; it will remain as a legacy reference point until the `v1` implementation is feature-complete and verified.
+
+---
+
+## 7. Next Steps
+
+1.  **Initialize `api/v1` Spec Suite:** Create `spec/requests/api/v1/` to house the initial Red tests.
+2.  **First Slice (Shows):** Implement the `ShowPresenter` and `ShowService` via a Red-Green-Refactor cycle for the `GET /api/v1/shows` endpoint.
+3.  **Standardized Error Handling:** Implement the `ErrorPresenter` to replace plain-text error messages.
+4.  **Integration Testing:** Ensure all `v1` endpoints are covered by request specs before any `v0.1` routes are deprecated.

--- a/docs/handoff_junior_refactor_v1.md
+++ b/docs/handoff_junior_refactor_v1.md
@@ -1,0 +1,74 @@
+# Refactor Task: Implementing ShowService and ShowPresenter
+
+## Status: Ready for Implementation
+**Target Audience:** Junior Engineering Team
+
+---
+
+## 1. Architectural Context
+We've just reached a "Green" state in our TDD cycle for `GET /api/v1/user/:name/shows`. However, the current code in `silo_night.rb` is problematic because it mixes **orchestration** (finding the user) and **presentation** (shaping the JSON) directly in the route.
+
+Your goal is to perform the **Refactor** step: move this logic into dedicated objects that follow the **Single Responsibility Principle (SRP)**.
+
+---
+
+## 2. Part A: The `ShowPresenter` (The "What")
+
+### Why?
+Models like `Show` contain all kinds of data (database IDs, internal timestamps, raw strings). We shouldn't just dump all of that into our API. The `ShowPresenter` acts as a "filter" and a "decorator" that ensures the front-end gets exactly what it needs, in the correct format.
+
+### Your Instructions:
+1.  **Create a new file:** `lib/presenters/show_presenter.rb`.
+2.  **Define the class:** It should take a `Show` object in its constructor.
+3.  **Implement a `to_h` (or `as_json`) method:** This method should return a hash with the following keys:
+    - `id`: The show's database ID.
+    - `name`: The display name.
+    - `runtime`: The runtime (as an integer).
+    - `uri_safe_name`: The `uri_encoded` field from the model.
+    - `poster_url`: A "decorated" version of `poster_path`. (Hint: If it starts with `/`, prepend the TMDB base URL `https://image.tmdb.org/t/p/w500`).
+4.  **Requirement:** Do not touch the `Show` model itself. All formatting happens here.
+
+---
+
+## 3. Part B: The `ShowService` (The "How")
+
+### Why?
+Routes should be "thin shims." They should only handle the HTTP request and immediately hand off the real work to a "Service." This makes our business logic testable without needing to boot up a web server.
+
+### Your Instructions:
+1.  **Create a new file:** `lib/services/show_service.rb`.
+2.  **Define a class method:** `self.list_for_user(user_name)`.
+3.  **Implementation logic:**
+    - Find the user by name using the `User` model.
+    - If the user doesn't exist, return `nil` or raise a custom `UserNotFoundError`.
+    - Fetch the shows associated with that user.
+    - Return the collection of shows.
+4.  **Goal:** This service should eventually handle adding, removing, and reordering shows, but for now, focus only on the `list_for_user` functionality.
+
+---
+
+## 4. Final Integration (The Refactor)
+
+Once your Service and Presenter are ready, you'll update the route in `silo_night.rb` to look like this:
+
+```ruby
+get '/user/:name/shows' do
+  content_type :json
+  shows = Services::ShowService.list_for_user(params[:name])
+  return status 404 unless shows
+  
+  shows.map { |s| Presenters::ShowPresenter.new(s).to_h }.to_json
+end
+```
+
+### Success Criteria:
+- Run `bundle exec rspec spec/requests/api/v1/shows_spec.rb`.
+- **The test must stay Green.** If it turns Red, check if you renamed any JSON keys or if your `poster_url` logic changed the expected output.
+
+---
+
+## 5. Why This Matters
+By doing this, you're making the system:
+- **Testable:** We can now write a unit test for `ShowPresenter` without needing a database.
+- **Maintainable:** If we decide to use a different image provider for posters, we only change one line in the `ShowPresenter`.
+- **Flexible:** The front-end team can now trust that *every* endpoint returning a show will use this exact same structure.

--- a/silo_night.rb
+++ b/silo_night.rb
@@ -97,6 +97,24 @@ post '/user/:name/availability' do
   slim :schedule_edit
 end
 
+namespace '/api/v1' do
+  get '/user/:name/shows' do
+    content_type :json
+    u = User.find(name: params["name"])
+    return status 404 if u.nil?
+    
+    u.shows.map do |s|
+      {
+        id: s.id,
+        name: s.name,
+        runtime: s.runtime,
+        uri_safe_name: s.uri_encoded,
+        poster_url: s.poster_path # Minimal implementation
+      }
+    end.to_json
+  end
+end
+
 namespace '/api/v0.1' do
 
   delete '/user/:name' do

--- a/spec/requests/api/v1/shows_spec.rb
+++ b/spec/requests/api/v1/shows_spec.rb
@@ -1,0 +1,43 @@
+# spec/requests/api/v1/shows_spec.rb
+
+require 'spec_helper'
+require 'rack/test'
+require 'silo_night'
+
+RSpec.describe 'API v1 Shows', type: :request do
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  let(:user_name) { 'test_user' }
+  let!(:user) { User.create(name: user_name) }
+  let!(:show1) { Show.create(name: 'The Expanse', runtime: 60, uri_encoded: 'the+expanse') }
+  let!(:show2) { Show.create(name: 'Firefly', runtime: 45, uri_encoded: 'firefly') }
+
+  before do
+    user.add_show(show1)
+    user.add_show(show2)
+  end
+
+  describe 'GET /api/v1/user/:name/shows' do
+    it 'returns a 200 OK and a list of shows in the standardized format' do
+      get "/api/v1/user/#{user_name}/shows"
+
+      expect(last_response.status).to eq(200)
+      
+      json = JSON.parse(last_response.body)
+      expect(json).to be_an(Array)
+      expect(json.size).to eq(2)
+
+      # Verify the standardized contract (ShowPresenter output)
+      show_json = json.first
+      expect(show_json).to have_key('id')
+      expect(show_json).to have_key('name')
+      expect(show_json).to have_key('runtime')
+      expect(show_json).to have_key('uri_safe_name')
+      expect(show_json).to have_key('poster_url')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,19 @@
+require 'cgi'
+# Fallback for older CGI/VCR compatibility issues
+unless CGI.respond_to?(:parse)
+  def CGI.parse(query)
+    params = {}
+    query.split(/[&;]/).each do |pairs|
+      key, value = pairs.split('=', 2).map { |v| CGI.unescape(v) }
+      if params.has_key?(key)
+        params[key] << value
+      else
+        params[key] = [value]
+      end
+    end
+    params
+  end
+end
 ENV['RACK_ENV'] = 'test'
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift File.expand_path('..', __dir__)


### PR DESCRIPTION
## 🚀 Pull Request: Initialize API v1 (TDD & Architectural Refactor)

### **Purpose**
This PR establishes the foundation for a versioned API (v1) designed to support rapid front-end UI prototyping. It introduces a **Test-Driven Development (TDD)** workflow and a decoupled architectural pattern using **Services** and **Presenters**.

### **Key Changes**
- **Contract-First Specs:** Added `spec/requests/api/v1/shows_spec.rb` to define the JSON contract for the `GET /api/v1/user/:name/shows` endpoint.
- **Minimal API v1 Implementation:** Added the `/api/v1` namespace in `silo_night.rb` with a "Green" implementation of the user shows list.
- **Architectural Documentation:** 
  - `docs/architecture_proposal_api_v1.md`: A high-level roadmap for the `v1` refactor, detailing assumptions, biases, and the Red-Green-Refactor cycle.
  - `docs/handoff_junior_refactor_v1.md`: Explicit, educational instructions for the junior engineering team to perform the "Refactor" step of the TDD cycle.
- **Dependency Fix:** Resolved a compatibility issue with `CGI.parse` in the test environment to allow the spec suite to run cleanly.

### **Current Status**
The `GET /api/v1/user/:name/shows` endpoint is currently in a **Green** state, passing its request spec. It is ready for the Refactor phase, which will move its logic into dedicated `ShowService` and `ShowPresenter` objects.