### PR TITLE
API Migration and UI Fixes

### DIFF
--- a/public/javascript/default.js
+++ b/public/javascript/default.js
@@ -298,9 +298,9 @@ function renderShows(shows) {
     var li = document.createElement('li');
     li.className = 'list-item';
     
-    if (s.poster_path) {
+    if (s.poster_url) {
       var img = document.createElement('img');
-      img.src = s.poster_path;
+      img.src = s.poster_url;
       img.className = 'show-poster';
       li.appendChild(img);
     }
@@ -317,7 +317,7 @@ function renderShows(shows) {
 
     var runtimeSpan = document.createElement('span');
     runtimeSpan.className = 'runtime';
-    runtimeSpan.textContent = s.runtime;
+    runtimeSpan.textContent = s.runtime + ' minutes';
     li.appendChild(runtimeSpan);
 
     var removeSpan = document.createElement('span');

--- a/public/javascript/default.js
+++ b/public/javascript/default.js
@@ -276,6 +276,12 @@ function addShow(name) {
     body: JSON.stringify({ name: name }),
     headers: { 'Content-Type': 'application/json' }
   })
+  .then(response => {
+    if (response.ok) {
+      // Fetch the full list to refresh the UI
+      return fetch('/api/v1/user/' + username + '/shows');
+    }
+  })
   .then(response => response.json())
   .then(data => {
     renderShows(data);

--- a/public/javascript/default.js
+++ b/public/javascript/default.js
@@ -277,15 +277,24 @@ function addShow(name) {
     headers: { 'Content-Type': 'application/json' }
   })
   .then(response => {
-    if (response.ok) {
-      // Fetch the full list to refresh the UI
-      return fetch('/api/v1/user/' + username + '/shows');
+    if (!response.ok) {
+      throw new Error('Failed to add show: ' + response.statusText);
     }
+    // Fetch the full list to refresh the UI
+    return fetch('/api/v1/user/' + username + '/shows');
   })
-  .then(response => response.json())
+  .then(response => {
+    if (!response.ok) {
+      throw new Error('Failed to fetch updated shows list');
+    }
+    return response.json();
+  })
   .then(data => {
     renderShows(data);
     searchInput.value = '';
+  })
+  .catch(error => {
+    console.error('Error:', error);
   });
 }
 

--- a/public/javascript/default.js
+++ b/public/javascript/default.js
@@ -14,12 +14,11 @@ function removeShow(name, li) {
   var username = window.location.pathname.split('/')[2];
   if (!username) return;
 
-  fetch('/api/v0.1/user/' + username + '/show/' + encodeURIComponent(name), {
+  fetch('/api/v1/user/' + username + '/shows/' + encodeURIComponent(name), {
     method: 'DELETE'
   })
-  .then(response => response.json())
-  .then(data => {
-    li.remove();
+  .then(response => {
+    if (response.ok) li.remove();
   });
 }
 
@@ -134,7 +133,7 @@ function saveNewOrder() {
   var showNames = Array.from(document.querySelectorAll("ul#show.list li"))
     .map(li => li.querySelector('.name').textContent.trim());
 
-  fetch('/api/v0.1/user/' + username + '/shows/reorder', {
+  fetch('/api/v1/user/' + username + '/shows/reorder', {
     method: 'POST',
     body: JSON.stringify(showNames),
     headers: { 'Content-Type': 'application/json' }
@@ -227,7 +226,7 @@ if (searchInput) {
     }
 
     debounceTimer = setTimeout(function() {
-      fetch('/api/v0.1/search?q=' + encodeURIComponent(query))
+      fetch('/api/v1/search?q=' + encodeURIComponent(query))
         .then(response => response.json())
         .then(data => {
           renderSuggestions(data);
@@ -272,12 +271,10 @@ function addShow(name) {
   var username = window.location.pathname.split('/')[2];
   if (!username) return;
 
-  var formData = new FormData();
-  formData.append('show', name);
-
-  fetch('/api/v0.1/user/' + username + '/show', {
+  fetch('/api/v1/user/' + username + '/shows', {
     method: 'POST',
-    body: formData
+    body: JSON.stringify({ name: name }),
+    headers: { 'Content-Type': 'application/json' }
   })
   .then(response => response.json())
   .then(data => {

--- a/silo_night.rb
+++ b/silo_night.rb
@@ -173,17 +173,20 @@ namespace '/api/v1' do
     return [404, Presenters::Error.new("User not found", 404).to_h.to_json] unless user
 
     new_order = JSON.parse(request.body.read)
-    
+    current_show_names = user.shows.map(&:name)
+
+    unless new_order.is_a?(Array) && new_order.sort == current_show_names.sort
+      return [422, Presenters::Error.new("Invalid show order", 422).to_h.to_json]
+    end
+
     DB.transaction do
       new_order.each_with_index do |show_name, index|
         show = Show.find(name: show_name)
-        if show
-          DB[:shows_users].where(user_id: user.id, show_id: show.id).update(show_order: index)
-        end
+        DB[:shows_users].where(user_id: user.id, show_id: show.id).update(show_order: index)
       end
     end
     user.generate_schedule
-    
+
     user.reload.shows.map { |s| Presenters::Show.new(s).to_h }.to_json
   end
 

--- a/silo_night.rb
+++ b/silo_night.rb
@@ -167,6 +167,26 @@ namespace '/api/v1' do
     [404, Presenters::Error.new("Show not found", 404).to_h.to_json]
   end
 
+  post '/user/:name/shows/reorder' do
+    content_type :json
+    user = User.find(name: params[:name])
+    return [404, Presenters::Error.new("User not found", 404).to_h.to_json] unless user
+
+    new_order = JSON.parse(request.body.read)
+    
+    DB.transaction do
+      new_order.each_with_index do |show_name, index|
+        show = Show.find(name: show_name)
+        if show
+          DB[:shows_users].where(user_id: user.id, show_id: show.id).update(show_order: index)
+        end
+      end
+    end
+    user.generate_schedule
+    
+    user.reload.shows.map { |s| Presenters::Show.new(s).to_h }.to_json
+  end
+
   patch '/user/:name/shows/:show_name' do
     content_type :json
     user = User.find(name: params[:name])

--- a/spec/requests/api/v1/js_compatibility_spec.rb
+++ b/spec/requests/api/v1/js_compatibility_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'JavaScript API Compatibility', type: :request do
 
   describe 'Add Show (POST)' do
     context 'v0.1 style (as currently implemented in default.js for v1)' do
-      it 'v0.1 endpoint passes with FormData' do
+      it 'v0.1 endpoint passes with form-encoded params' do
         post "/api/v0.1/user/#{username}/show", { show: show_name }
         expect(last_response.status).to eq(200)
       end
@@ -57,6 +57,9 @@ RSpec.describe 'JavaScript API Compatibility', type: :request do
       it 'v1 endpoint succeeds with bulk POST (if implemented)' do
         post "/api/v1/user/#{username}/shows/reorder", new_order.to_json, { 'CONTENT_TYPE' => 'application/json' }
         expect(last_response.status).to eq(200)
+
+        user = User.find(name: username)
+        expect(user.shows.map(&:name)).to eq(new_order)
       end
     end
   end

--- a/spec/requests/api/v1/js_compatibility_spec.rb
+++ b/spec/requests/api/v1/js_compatibility_spec.rb
@@ -1,0 +1,63 @@
+# spec/requests/api/v1/js_compatibility_spec.rb
+require 'spec_helper'
+
+RSpec.describe 'JavaScript API Compatibility', type: :request do
+  let(:username) { 'sam' }
+  let(:show_name) { 'Silo' }
+
+  before do
+    User.create(name: username)
+    Show.create(name: show_name, runtime: '50', uri_encoded: 'silo')
+  end
+
+  describe 'Add Show (POST)' do
+    context 'v0.1 style (as currently implemented in default.js for v1)' do
+      it 'v0.1 endpoint passes with FormData' do
+        post "/api/v0.1/user/#{username}/show", { show: show_name }
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'v1 endpoint succeeds with v1-style request' do
+        # We expect this to fail currently because the JS pattern doesn't match the v1 API contract yet
+        post "/api/v1/user/#{username}/shows", { name: show_name }.to_json, { 'CONTENT_TYPE' => 'application/json' }
+        expect(last_response.status).to eq(201)
+      end
+    end
+  end
+
+  describe 'Remove Show (DELETE)' do
+    before do
+      user = User.find(name: username)
+      show = Show.find(name: show_name)
+      Services::UserShow.add_show(user, show)
+    end
+
+    context 'v1 style' do
+      it 'v1 endpoint succeeds with v1-style path' do
+        # default.js currently uses /api/v1/user/.../show/:name
+        # We want it to use /api/v1/user/.../shows/:name
+        delete "/api/v1/user/#{username}/shows/#{show_name}"
+        expect(last_response.status).to eq(204)
+      end
+    end
+  end
+
+  describe 'Reorder Shows (POST)' do
+    before do
+      user = User.find(name: username)
+      show1 = Show.find(name: show_name)
+      show2 = Show.create(name: 'Foundation', runtime: '60')
+      Services::UserShow.add_show(user, show1)
+      Services::UserShow.add_show(user, show2)
+    end
+
+    context 'v1 style' do
+      let(:new_order) { ['Foundation', 'Silo'] }
+
+      it 'v1 endpoint succeeds with bulk POST (if implemented)' do
+        post "/api/v1/user/#{username}/shows/reorder", new_order.to_json, { 'CONTENT_TYPE' => 'application/json' }
+        expect(last_response.status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request: API Migration and UI Fixes

## Overview
This PR completes the migration of the frontend `default.js` logic to consume the `v1` API contract, ensuring consistent path structures and JSON payload handling.

## Changes

### Backend
- **New Endpoint:** Added `POST /api/v1/user/:name/shows/reorder` to support bulk reordering in the frontend.
- **Presenter Adherence:** Updated the backend to leverage `Presenters::Show` consistently for API responses.

### Frontend
- **API Migration:**
  - Migrated `removeShow`, `addShow`, and `saveNewOrder` from `v0.1` endpoints to `v1` endpoints.
  - Switched `addShow` from `FormData` to `application/json` to match the `v1` contract.
  - Implemented a mandatory full-list fetch after `addShow` to keep the UI state in sync with the backend.
- **UI Rendering:**
  - Updated `renderShows` to map to the new `poster_url` field instead of `poster_path`.
  - Added "minutes" suffix to runtime display.

### Testing
- **New Test Coverage:** Created `spec/requests/api/v1/js_compatibility_spec.rb` to verify the `v1` API contract for all updated endpoints.

## Verification
- All tests in `spec/requests/api/v1/js_compatibility_spec.rb` are passing (4/4).
- Manual verification confirms the UI correctly renders posters and correctly updates the shows list after an add operation.
